### PR TITLE
Fix test to import grokcore.json.testing properly

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ Changes
 1.2.2 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fix view_lookup test.
 
 
 1.2.1 (2016-02-15)

--- a/src/grokcore/json/tests/json/view_lookup.py
+++ b/src/grokcore/json/tests/json/view_lookup.py
@@ -3,7 +3,8 @@
 The JSON grokker registers a view for each method of the JSON class.
 So we should be able to search for view by method name.
 
-  >>> grok.testing.grok(__name__)
+  >>> from grokcore.json import testing
+  >>> testing.grok(__name__)
   >>> mammoth = Mammoth()
   >>> from zope.publisher.browser import TestRequest
   >>> request = TestRequest()


### PR DESCRIPTION
Make sure that `testing.grok()` is imported properly at the beginning
of `view_lookup` test module. This could fail before, depending on the
order of test files read in `test_package`. Therefore it might have
been overlooked before.