### PR TITLE
Set correct package name in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,4 @@
+grokcore.json
+*************
+
+Support for JSON views in `grok`.

--- a/README.txt
+++ b/README.txt
@@ -1,2 +1,0 @@
-grokcore.viewlet
-****************

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
 long_description = (
-    read('README.txt')
+    read('README.rst')
     + '\n' +
     read('CHANGES.txt')
     )


### PR DESCRIPTION
Cosmetics, but at least the package name should be displayed correctly.

Also changed filename extension: .rst is nicer to view on github than .txt (with REStructuredText inside).
